### PR TITLE
Changes to train_data_tokenize.py and est_data_tokenize.py

### DIFF
--- a/preproc/test_data_tokenize.py
+++ b/preproc/test_data_tokenize.py
@@ -19,7 +19,7 @@ class Consumer(multiprocessing.Process):
 
 		self.tokenizer = StanfordTokenizer(options={"ptb3Escaping": True})
 		print '%s: Loading pickles...' % self.name
-		self.map_word_index = pickle.load(map_word_index_model)
+		self.map_word_index = pickle.loads(map_word_index_model)
 		print '%s: Done.' % self.name
 
 	def run(self):

--- a/preproc/test_data_tokenize.py
+++ b/preproc/test_data_tokenize.py
@@ -7,6 +7,9 @@ import sys
 from nltk.tokenize import StanfordTokenizer
 print('Imports Done.')
 
+file_path=open('preproc/map_word_index.pkl', 'rb')
+map_word_index_model=pickle.load(file_path)
+
 class Consumer(multiprocessing.Process):
 	def __init__(self, task_queue, result_queue):
 		
@@ -16,7 +19,7 @@ class Consumer(multiprocessing.Process):
 
 		self.tokenizer = StanfordTokenizer(options={"ptb3Escaping": True})
 		print '%s: Loading pickles...' % self.name
-		self.map_word_index = pickle.load(open('preproc/map_word_index.pkl', 'r'))
+		self.map_word_index = pickle.load(map_word_index_model)
 		print '%s: Done.' % self.name
 
 	def run(self):

--- a/preproc/test_data_tokenize.py
+++ b/preproc/test_data_tokenize.py
@@ -19,7 +19,7 @@ class Consumer(multiprocessing.Process):
 
 		self.tokenizer = StanfordTokenizer(options={"ptb3Escaping": True})
 		print '%s: Loading pickles...' % self.name
-		self.map_word_index = pickle.loads(map_word_index_model)
+		self.map_word_index = map_word_index_model
 		print '%s: Done.' % self.name
 
 	def run(self):

--- a/preproc/train_data_tokenize.py
+++ b/preproc/train_data_tokenize.py
@@ -57,6 +57,7 @@ print('Done.')
 
 print('Saving cleaned data...')
 train_data.to_csv('input_clean/train_clean.csv', )
+train_data.fillna('', inplace=True)
 print('Done.')
 
 words = list(words)


### PR DESCRIPTION
**train_data_tokenize.py**

The training data from kaggle dataset contains 2 rows in which the "question2" column has NAN values.
 Without replacing NAN values with empty "" , the code gives an error while executing this file as various functions like word.strip() cannot work on NAN values. Performing the commited change solves the issue.

**test_data_tokenize.py**

Since _self.map_word_index = pickle.load(open('preproc/map_word_index.pkl', 'r'))_  is being called multiple times for each cpu thread allocation, the above pickle model is only unpickling the first time it is being called, for rest calls it is showing EOF(End of file error).
This is because Pickle keeps track of the objects it has already serialized, so later references to the same object won’t be serialized again.
This issue was solved by unplickling _map_word_index.pkl_ initially in a global scope and assigning this unpickled object to _self.map_word_index_  for every thread it is being called for.
Hope this helps. Please do let me know.
![Screenshot (40)](https://user-images.githubusercontent.com/42846105/79852955-0867ef00-83e5-11ea-8f04-6f8c1eb1e48d.png)




